### PR TITLE
Improve Dockerfile to include renv pre-installed packages

### DIFF
--- a/Dockerfile-quarto
+++ b/Dockerfile-quarto
@@ -1,6 +1,9 @@
 ARG ROCKERVER=verse:4.4.0
 FROM rocker/$ROCKERVER
 
-
 RUN curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb \
   && DEBIAN_FRONTEND=noninteractive apt install ./quarto-linux-amd64.deb
+
+COPY presentation/renv.lock /home/rstudio/renv.lock
+RUN R -e "install.packages('renv')"
+RUN R -e "renv::restore(lockfile = '/home/rstudio/renv.lock')"


### PR DESCRIPTION
Fixes #3

Update `Dockerfile-quarto` to install `renv` packages from `presentation/renv.lock`.

* Copy `presentation/renv.lock` to `/home/rstudio/renv.lock`.
* Install the `renv` package using `R -e "install.packages('renv')"`
* Restore the `renv` environment using `R -e "renv::restore(lockfile = '/home/rstudio/renv.lock')"`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsvilhuber/reproducibility-for-llm/pull/4?shareId=63b12055-a566-4e7b-9d74-9820b3c3a296).